### PR TITLE
fix(sqp): Request metrics chunk in the default queryer

### DIFF
--- a/lib/svrquery/protocol/sqp/query.go
+++ b/lib/svrquery/protocol/sqp/query.go
@@ -19,7 +19,7 @@ type queryer struct {
 }
 
 func newCreator(c protocol.Client) protocol.Queryer {
-	return newQueryer(ServerInfo, DefaultMaxPacketSize, c)
+	return newQueryer(ServerInfo|Metrics, DefaultMaxPacketSize, c)
 }
 
 func newQueryer(requestedChunks byte, maxPktSize int, c protocol.Client) *queryer {


### PR DESCRIPTION
When a client was created using svrquery.NewClient() then c.Query() was executed only server info chunk was going to be requested by default.

This fix adds the metrics chunk to the requested chunks used in the default queryer.

This was missed from the previous commit.